### PR TITLE
Fix retry loop variable shadowing and division by zero in profit display

### DIFF
--- a/ibkr.lua
+++ b/ibkr.lua
@@ -85,7 +85,7 @@ function RefreshAccount(account, since)
           statementContent, charset, mimeType = connection:get(
               "https://ndcdyn.interactivebrokers.com/Universal/servlet/FlexStatementService.GetStatement?t=" .. token ..
                   "&q=" .. code .. "&v=3")
-          local ec=parseBlock(statementContent, 'ErrorCode')
+          ec=parseBlock(statementContent, 'ErrorCode')
           if ec=="1019" then
               MM.sleep(1)
           end
@@ -113,7 +113,7 @@ function RefreshAccount(account, since)
               currencyOfPurchasePrice = pos.currency,
               exchangeRate = 1 / pos.fxRateToBase,
               amount = pos.positionValue * pos.fxRateToBase,
-              userdata = {{key="_profit",value=string.format("%.02f", pos.fifoPnlUnrealized*pos.fxRateToBase) .. " EUR / " .. string.format("%.05f", 100/pos.costBasisMoney*pos.positionValue-100) .. " %"}}
+              userdata = {{key="_profit",value=string.format("%.02f", pos.fifoPnlUnrealized*pos.fxRateToBase) .. " EUR" .. (pos.costBasisMoney ~= "0" and (" / " .. string.format("%.05f", 100/pos.costBasisMoney*pos.positionValue-100) .. " %") or "")}}
               --userdata = {{key="_profit",value=string.format("%.02f", pos.fifoPnlUnrealized) .. " USD / " .. string.format("%.05f", 100/pos.costBasisMoney*pos.positionValue-100) .. " %"}}
 
           }


### PR DESCRIPTION
## Bugs fixed

**Bug 1 – retry loop never retries (line 88)**

`local ec` inside the `repeat` block shadows the outer `ec`, so the `until ec ~= "1019"` condition always evaluates the outer variable (which is `nil`). Since `nil ~= "1019"` is always true, the loop exits after the first iteration regardless of the error code. If IBKR returns error 1019 ("statement not ready"), the script proceeds with the error response instead of waiting and retrying.

Fix: remove the `local` keyword so the assignment updates the variable that `until` checks.

**Bug 2 – division by zero in profit percentage (line 116)**

`100/pos.costBasisMoney` crashes when `costBasisMoney` is `"0"`, which happens for positions without a tracked cost basis. In that case the percentage part is now omitted and only the absolute P&L in EUR is shown.

## Test plan
- [ ] Verify normal account refresh still shows positions and profit/loss
- [ ] Verify positions with missing cost basis no longer crash
- [ ] Verify account refresh retries correctly when IBKR returns error 1019

🤖 Generated with [Claude Code](https://claude.com/claude-code)