### PR TITLE
Fix futures (FUT) distorting account NAV and quantity

### DIFF
--- a/ibkr.lua
+++ b/ibkr.lua
@@ -247,7 +247,8 @@ function RefreshAccount(account, since)
               isin = pos.isin,
               securityNumber = pos.isin,
               market = pos.listingExchange,
-              quantity = position * multiplier,
+              -- Futures: report number of contracts. Stocks/options keep share-equivalent (position x multiplier).
+              quantity = pos.assetCategory == "FUT" and position or position * multiplier,
               originalAmount = positionValue,
               originalCurrencyAmount = positionValue,
               currencyOfOriginalAmount = pos.currency,
@@ -258,7 +259,11 @@ function RefreshAccount(account, since)
               exchangeRateOfPrice = fxRateToBase,
               exchangeRateOfPurchasePrice = fxRateToBase,
               exchangeRate = 1 / fxRateToBase,
-              amount = positionValue * fxRateToBase,
+              -- Futures contribute 0 to NAV: IB settles futures variation margin to cash daily,
+              -- so the P&L is already reflected in the cash balance; counting positionValue
+              -- (notional) OR fifoPnlUnrealized here double-counts. Verified against IB Net
+              -- Liquidation Value. (Position is still visible via quantity + the _profit label.)
+              amount = (pos.assetCategory == "FUT" and 0 or positionValue) * fxRateToBase,
               userdata = {{key="_profit",value=string.format("%.02f", fifoPnlUnrealized*fxRateToBase) .. " EUR / " .. string.format("%.05f", profitPercent) .. " %"}}
               --userdata = {{key="_profit",value=string.format("%.02f", pos.fifoPnlUnrealized) .. " USD / " .. string.format("%.05f", 100/pos.costBasisMoney*pos.positionValue-100) .. " %"}}
 


### PR DESCRIPTION
Futures positions currently break the account balance.

In `RefreshAccount` every `OpenPosition` is reported with:

```lua
quantity = position * multiplier,
...
amount   = positionValue * fxRateToBase,
```

For a future, `positionValue` is the **notional** value of the contract — vastly larger than the capital actually at risk. A single futures contract therefore adds tens of thousands to the reported NAV and makes the account total meaningless. `position * multiplier` is also misleading as a quantity for futures.

## Fix — special-case `assetCategory == "FUT"`

```lua
quantity = pos.assetCategory == "FUT" and position or position * multiplier,
...
amount   = (pos.assetCategory == "FUT" and 0 or positionValue) * fxRateToBase,
```

- **Quantity:** futures report the number of contracts (`position`); stocks/options keep `position * multiplier`.
- **NAV:** futures contribute **0**. IB settles futures variation margin to **cash daily**, so the position's P&L is *already* reflected in the cash balance. Contributing the notional `positionValue` **or** the unrealized P&L (`fifoPnlUnrealized`) on top of that **double-counts**.

## Why 0 and not the unrealized P&L

I originally considered `fifoPnlUnrealized` (better than notional, but still wrong). Reconciling against **IB's own Net Liquidation Value** settled it: with futures contributing 0, `non-futures securities MV + total cash` matches IB NLV to within intraday price drift; adding the futures P&L put the total off by exactly that P&L. IB's own per-segment view confirms it — the Commodities (futures) segment reports `NLV == Cash`, i.e. the futures add nothing to net liq beyond their margin cash.

The futures position stays **visible** — its `quantity` and the `_profit` (P&L) userdata label are unchanged; only the phantom NAV contribution is removed.

## Caveat

Verified against a live USD-base account with a short index future (MES). The mechanism — daily MTM settling to cash — is currency-agnostic, so this should hold for EUR-base accounts too, but I have not tested one directly. If you would rather keep the unrealized P&L visible in the portfolio *total* (accepting the double-count), that is a reasonable product call — happy to adjust.

Stocks and options are completely unchanged, and the base currency stays EUR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)